### PR TITLE
Fix typo in cell info comment

### DIFF
--- a/src/pages/dashboard/cpns/RightCellInfo/index.tsx
+++ b/src/pages/dashboard/cpns/RightCellInfo/index.tsx
@@ -39,8 +39,8 @@ const RightCellInfo: React.FC<IProps> = ({ graph, curCell }) => {
       return
     }
     const curNode = curCell.cell
-    console.log('获取当强cell的信息.....', curNode)
-    // console.log('获取当强cell的信息.....', curNode?.prop())
+    console.log('获取当前cell的信息.....', curNode)
+    // console.log('获取当前cell的信息.....', curNode?.prop())
     // curNode?.attr('label/text', 'kafka-topic-01-....')
   }
   return (


### PR DESCRIPTION
## Summary
- fix a Chinese typo in RightCellInfo comment

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config)*
- `npx prettier -c --write src/pages/dashboard/cpns/RightCellInfo/index.tsx`
